### PR TITLE
Add Rust dependency caching to CI workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,17 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-x86_64-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-x86_64-
+            ${{ runner.os }}-cargo-
       - name: "Build wheels - x86_64"
         uses: PyO3/maturin-action@v1
         with:
@@ -37,6 +48,17 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-universal-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-universal-
+            ${{ runner.os }}-cargo-
       - name: "Build wheels - universal"
         uses: PyO3/maturin-action@v1
         with:
@@ -60,6 +82,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Configure Git to support long paths"
         run: git config --system core.longpaths true
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ matrix.platform.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.platform.target }}-
+            ${{ runner.os }}-cargo-
       - name: "Build wheels - windows"
         uses: PyO3/maturin-action@v1
         with:
@@ -80,6 +113,17 @@ jobs:
           - i686-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.target }}-
+            ${{ runner.os }}-cargo-
       - name: "Build wheels - linux"
         uses: PyO3/maturin-action@v1
         with:
@@ -112,6 +156,18 @@ jobs:
             arch: ppc64
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cross-${{ matrix.platform.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-cross-${{ matrix.platform.target }}-
+            ${{ runner.os }}-cargo-cross-
+            ${{ runner.os }}-cargo-
       - name: "Build wheels - linux-cross"
         uses: PyO3/maturin-action@v1
         with:
@@ -135,6 +191,18 @@ jobs:
           - i686-unknown-linux-musl
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-musl-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-musl-${{ matrix.target }}-
+            ${{ runner.os }}-cargo-musl-
+            ${{ runner.os }}-cargo-
       - name: "Build wheels - musllinux"
         uses: PyO3/maturin-action@v1
         with:
@@ -160,6 +228,19 @@ jobs:
             arch: armv7
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-musl-cross-${{ matrix.platform.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-musl-cross-${{ matrix.platform.target }}-
+            ${{ runner.os }}-cargo-musl-cross-
+            ${{ runner.os }}-cargo-musl-
+            ${{ runner.os }}-cargo-
       - name: "Build wheels - musllinux-cross"
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
Introduced actions/cache steps to all build jobs in the CI workflow to cache Rust dependencies and build artifacts. This change aims to speed up CI runs by reusing cached Cargo registry, git, and target directories across builds.