### PR TITLE
Resolve qualified name once in classify_base

### DIFF
--- a/src/class_diagram/mod.rs
+++ b/src/class_diagram/mod.rs
@@ -385,23 +385,21 @@ impl ClassDiagram {
             return BaseKind::Skip;
         }
 
-        if checker
-            .semantic()
-            .resolve_qualified_name(base)
-            .is_some_and(|name| {
-                matches!(name.segments(), ["typing", "Generic"])
-                    || matches!(name.segments(), ["" | "builtins", "object"])
-                    || matches!(name.segments(), ["abc", "ABC" | "ABCMeta"])
-                    || matches!(
-                        name.segments(),
-                        ["typing" | "typing_extensions", "Protocol"]
-                    )
-            })
-        {
+        let qualified_name = checker.semantic().resolve_qualified_name(base);
+
+        if qualified_name.as_ref().is_some_and(|name| {
+            matches!(name.segments(), ["typing", "Generic"])
+                || matches!(name.segments(), ["" | "builtins", "object"])
+                || matches!(name.segments(), ["abc", "ABC" | "ABCMeta"])
+                || matches!(
+                    name.segments(),
+                    ["typing" | "typing_extensions", "Protocol"]
+                )
+        }) {
             return BaseKind::Skip;
         }
 
-        let base_name = checker.semantic().resolve_qualified_name(base).map_or_else(
+        let base_name = qualified_name.map_or_else(
             || {
                 let name = checker.locator().slice(base);
                 QualifiedName::user_defined(name).normalize_name()


### PR DESCRIPTION
## Summary
- `classify_base` in `src/class_diagram/mod.rs` called `checker.semantic().resolve_qualified_name(base)` twice on the same `base` expression: once for the Skip-classification checks (Generic/object/ABC/Protocol) and again to compute `base_name` for the `InheritanceTarget` case.
- `resolve_qualified_name` performs scope/binding resolution and isn't free, so this change resolves it once into a local `qualified_name` and reuses it for both call sites.
- Pure refactor, no behavior change: the Skip-matching logic, ordering, and everything after it (`base_display`, `is_abstract_or_protocol`, `BaseKind::InheritanceTarget`) are untouched.

## Test plan
- `cargo test --verbose` - all 52 tests pass unchanged, including the ~29 tests in `src/class_diagram/tests.rs` covering inheritance/protocol/ABC/generic scenarios.
- `cargo clippy --all-targets --all-features -- -D warnings` - clean, no warnings.
- No new tests added since existing tests already cover `classify_base`'s behavior and this change is verified not to alter any expected output.