### PR TITLE
Deduplicate glob-pattern-building and fix panic on invalid CLI glob

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,10 @@ use clap::Parser;
 use log::info;
 use mermaider::Mermaider;
 use pymermaider_wasm::class_diagram;
-use ruff_linter::settings::types::{FilePattern, FilePatternSet, GlobPath};
-use settings::{FileResolverSettings, DEFAULT_EXCLUDES};
+use settings::FileResolverSettings;
 use std::io::Read as _;
 use std::io::Write as _;
 
-#[allow(clippy::too_many_lines)]
 fn main() {
     env_logger::init();
 
@@ -35,49 +33,17 @@ fn main() {
     let extend_exclude_patterns = args.extend_exclude.take();
     let include_patterns = args.include.take();
 
-    let include_patterns: Option<FilePatternSet> = include_patterns.map(|paths| {
-        FilePatternSet::try_from_iter(
-            paths
-                .into_iter()
-                .map(|pattern| {
-                    let absolute = GlobPath::normalize(&pattern, &project_root);
-                    FilePattern::User(pattern, absolute)
-                })
-                .collect::<Vec<_>>(),
-        )
-        .unwrap()
-    });
-
-    let file_settings = FileResolverSettings {
-        exclude: FilePatternSet::try_from_iter(exclude_patterns.map_or_else(
-            || DEFAULT_EXCLUDES.to_vec(),
-            |paths| {
-                paths
-                    .into_iter()
-                    .map(|pattern| {
-                        let absolute = GlobPath::normalize(&pattern, &project_root);
-                        FilePattern::User(pattern, absolute)
-                    })
-                    .collect::<Vec<_>>()
-            },
-        ))
-        .unwrap(),
-        extend_exclude: FilePatternSet::try_from_iter(
-            extend_exclude_patterns
-                .map(|paths| {
-                    paths
-                        .into_iter()
-                        .map(|pattern| {
-                            let absolute = GlobPath::normalize(&pattern, &project_root);
-                            FilePattern::User(pattern, absolute)
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default(),
-        )
-        .unwrap(),
-        include: include_patterns,
+    let file_settings = match FileResolverSettings::new(
+        exclude_patterns,
+        extend_exclude_patterns,
+        include_patterns,
         project_root,
+    ) {
+        Ok(settings) => settings,
+        Err(e) => {
+            eprintln!("error: invalid file pattern: {e}");
+            std::process::exit(2);
+        }
     };
 
     let mermaider = Mermaider::new(args, file_settings);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,6 @@
 use ruff_linter::settings::types::FilePattern;
+use ruff_linter::settings::types::GlobPath;
+use std::path::Path;
 use std::path::PathBuf;
 
 use ruff_linter::settings::types::FilePatternSet;
@@ -37,3 +39,47 @@ pub static DEFAULT_EXCLUDES: &[FilePattern] = &[
     FilePattern::Builtin("site-packages"),
     FilePattern::Builtin("venv"),
 ];
+
+/// Build a `FilePatternSet` from a list of user-supplied glob patterns, normalizing each
+/// pattern against `project_root`. Returns an error message (rather than panicking) if any
+/// pattern fails to parse.
+fn build_pattern_set(
+    patterns: Option<Vec<String>>,
+    project_root: &Path,
+) -> Result<FilePatternSet, String> {
+    let entries = patterns.unwrap_or_default().into_iter().map(|pattern| {
+        let absolute = GlobPath::normalize(&pattern, project_root);
+        FilePattern::User(pattern, absolute)
+    });
+    FilePatternSet::try_from_iter(entries).map_err(|e| e.to_string())
+}
+
+impl FileResolverSettings {
+    /// Construct a `FileResolverSettings` from the raw CLI-supplied pattern lists.
+    ///
+    /// Returns `Err` (instead of panicking) if any exclude/extend-exclude/include pattern
+    /// fails to parse as a valid glob.
+    pub fn new(
+        exclude_patterns: Option<Vec<String>>,
+        extend_exclude_patterns: Option<Vec<String>>,
+        include_patterns: Option<Vec<String>>,
+        project_root: PathBuf,
+    ) -> Result<Self, String> {
+        let exclude = match exclude_patterns {
+            Some(patterns) => build_pattern_set(Some(patterns), &project_root)?,
+            None => FilePatternSet::try_from_iter(DEFAULT_EXCLUDES.to_vec())
+                .map_err(|e| e.to_string())?,
+        };
+        let extend_exclude = build_pattern_set(extend_exclude_patterns, &project_root)?;
+        let include = include_patterns
+            .map(|patterns| build_pattern_set(Some(patterns), &project_root))
+            .transpose()?;
+
+        Ok(Self {
+            exclude,
+            extend_exclude,
+            include,
+            project_root,
+        })
+    }
+}

--- a/tests/cli_io.rs
+++ b/tests/cli_io.rs
@@ -206,3 +206,38 @@ fn multiple_files_with_stdout_errors() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("--multiple-files"));
 }
+
+#[test]
+fn invalid_exclude_glob_errors_cleanly_instead_of_panicking() {
+    let exe = env!("CARGO_BIN_EXE_pymermaider");
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    std::fs::write(dir.path().join("a.py"), "class A: ...\n").expect("write a.py");
+
+    let output = Command::new(exe)
+        .arg(dir.path().to_string_lossy().to_string())
+        .arg("--exclude")
+        .arg("[abc")
+        .arg("--output")
+        .arg("-")
+        .output()
+        .expect("run pymermaider");
+
+    assert!(
+        !output.status.success(),
+        "expected a non-zero exit status for an invalid --exclude glob"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked at"),
+        "stderr should not contain a panic backtrace: {stderr}"
+    );
+    assert!(
+        !stderr.contains("RUST_BACKTRACE"),
+        "stderr should not contain a panic backtrace: {stderr}"
+    );
+    assert!(
+        stderr.contains("error"),
+        "stderr should contain a clean error message: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- `main()` built the exclude/extend_exclude/include `FilePatternSet`s via the same map-normalize-collect shape three times (with only minor variation), which is why it needed `#[allow(clippy::too_many_lines)]`.
- Each of those three call sites also used `.unwrap()` on `FilePatternSet::try_from_iter`, so a malformed user-supplied `--exclude`/`--extend-exclude`/`--include` glob pattern would panic with a raw backtrace, instead of failing the same way every other user-input error in `main()` does (`eprintln!(...)` + `std::process::exit(N)`).
- Added `FileResolverSettings::new(...)` in `src/settings.rs`, which builds all three pattern sets through a shared `build_pattern_set` helper and returns `Result<Self, String>` instead of panicking.
- `main()` now calls `FileResolverSettings::new(...)` once and exits with code 2 (matching the existing convention for other user-input errors, e.g. `--multiple-files` with stdin) on invalid glob patterns.
- Removed `#[allow(clippy::too_many_lines)]` from `main()` since it's now well under the threshold after removing ~40 lines of duplicated pattern-building code.

## Test plan
- [x] `cargo test --verbose` (full suite, 53 tests passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo test --lib --no-default-features` (wasm-safety check, 39 tests passed, unaffected by this change)
- [x] Added `invalid_exclude_glob_errors_cleanly_instead_of_panicking` to `tests/cli_io.rs`, which passes a malformed `--exclude` glob (`[abc`, an unterminated character class) and asserts a non-zero exit status and that stderr contains a clean error message rather than a panic backtrace (no `panicked at` / `RUST_BACKTRACE`).