### PR TITLE
Deduplicate abc.ABC/ABCMeta qualified-name check

### DIFF
--- a/src/analysis/class_helpers.rs
+++ b/src/analysis/class_helpers.rs
@@ -11,6 +11,11 @@ pub trait QualifiedNameHelpers {
     fn normalize_name(&self) -> String;
 }
 
+/// Returns true if the qualified name resolves to `abc.ABC` or `abc.ABCMeta`.
+pub fn is_abc_qualified_name(name: &QualifiedName) -> bool {
+    matches!(name.segments(), ["abc", "ABC" | "ABCMeta"])
+}
+
 impl QualifiedNameHelpers for QualifiedName<'_> {
     fn normalize_name(&self) -> String {
         // make sure name is alphanumeric (including unicode), underscores, and dashes
@@ -44,7 +49,7 @@ impl ClassDefHelpers for ast::StmtClassDef {
 
         for base in args.iter().chain(keywords.iter().map(|kw| &kw.value)) {
             if let Some(qualified_name) = semantic.resolve_qualified_name(base) {
-                if matches!(qualified_name.segments(), ["abc", "ABC" | "ABCMeta"]) {
+                if is_abc_qualified_name(&qualified_name) {
                     return true;
                 }
             }

--- a/src/analysis/class_type_detector.rs
+++ b/src/analysis/class_type_detector.rs
@@ -1,5 +1,5 @@
 use super::checker::Checker;
-use super::class_helpers::ClassDefHelpers;
+use super::class_helpers::{is_abc_qualified_name, ClassDefHelpers};
 /// Utilities for detecting and classifying Python class types
 use crate::ast;
 use crate::render::renderer::ClassType;
@@ -57,7 +57,7 @@ impl<'a> ClassTypeDetector<'a> {
         class.bases().iter().any(|base| {
             self.semantic
                 .resolve_qualified_name(base)
-                .is_some_and(|name| matches!(name.segments(), ["abc", "ABC" | "ABCMeta"]))
+                .is_some_and(|name| is_abc_qualified_name(&name))
         })
     }
 
@@ -68,7 +68,7 @@ impl<'a> ClassTypeDetector<'a> {
         self.semantic
             .resolve_qualified_name(base_expr)
             .is_some_and(|name| {
-                matches!(name.segments(), ["abc", "ABC" | "ABCMeta"])
+                is_abc_qualified_name(&name)
                     || matches!(name.segments(), ["typing", "Protocol"])
                     || matches!(name.segments(), ["typing_extensions", "Protocol"])
             })

--- a/src/class_diagram/mod.rs
+++ b/src/class_diagram/mod.rs
@@ -1,5 +1,7 @@
 use crate::analysis::checker::Checker;
-use crate::analysis::class_helpers::{ClassDefHelpers, QualifiedNameHelpers};
+use crate::analysis::class_helpers::{
+    is_abc_qualified_name, ClassDefHelpers, QualifiedNameHelpers,
+};
 use crate::analysis::class_type_detector::ClassTypeDetector;
 use crate::analysis::parameter_generator::ParameterGenerator;
 use crate::analysis::type_analyzer;
@@ -390,7 +392,7 @@ impl ClassDiagram {
         if qualified_name.as_ref().is_some_and(|name| {
             matches!(name.segments(), ["typing", "Generic"])
                 || matches!(name.segments(), ["" | "builtins", "object"])
-                || matches!(name.segments(), ["abc", "ABC" | "ABCMeta"])
+                || is_abc_qualified_name(name)
                 || matches!(
                     name.segments(),
                     ["typing" | "typing_extensions", "Protocol"]


### PR DESCRIPTION
## Summary
- The `["abc", "ABC" | "ABCMeta"]` qualified-name check was independently written in 4 places: `analysis/class_helpers.rs` (`ClassDefHelpers::is_abstract`), `analysis/class_type_detector.rs` (private `is_abstract` and `is_stdlib_abstract_or_protocol`), and `class_diagram/mod.rs` (`classify_base`).
- Extracted a single `is_abc_qualified_name(&QualifiedName) -> bool` helper in `class_helpers.rs` and pointed all 4 call sites at it, so the ABC-detection rule only has to change in one place going forward.

## Test plan
- [x] `cargo test --verbose` (all tests pass, including ABC-detection unit tests and class_diagram abstract-base-class scenarios)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo test --lib --no-default-features` (wasm-safety check, unaffected)