### PR TITLE
Parallelize per-file parsing; fix O(n^2) abstract/interface lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
  "indexmap",
  "itertools 0.15.0",
  "log",
+ "rayon",
  "ruff_linter",
  "ruff_python_ast",
  "ruff_python_codegen",
@@ -1409,6 +1410,26 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ required-features = ["cli"]
 clap = { version = "4.5.51", features = ["derive"], optional = true }
 env_logger = { version = "0.11.8", default-features = false, features = ["auto-color", "color"], optional = true }
 ignore = { version = "0.4.25", features = ["simd-accel"], optional = true }
+rayon = { version = "1.10", optional = true }
 indexmap = "2.7.0"
 itertools = "0.15.0"
 log = "0.4.28"
@@ -48,7 +49,7 @@ ctor = "1.0.0"
 
 [features]
 default = ["cli"]
-cli = ["clap", "env_logger", "ignore"]
+cli = ["clap", "env_logger", "ignore", "dep:rayon"]
 
 [profile.release]
 lto = "fat"

--- a/src/class_diagram/mod.rs
+++ b/src/class_diagram/mod.rs
@@ -71,6 +71,11 @@ impl ClassDiagram {
         self.diagram.is_empty()
     }
 
+    pub fn merge(mut self, other: Self) -> Self {
+        self.diagram.extend(other.diagram);
+        self
+    }
+
     #[must_use]
     pub fn render(&self) -> Option<String> {
         if self.is_empty() {

--- a/src/mermaider.rs
+++ b/src/mermaider.rs
@@ -64,19 +64,21 @@ impl Mermaider {
             let parsed_files = self.parse_folder(root);
 
             if self.args.multiple_files {
-                let mut diagrams = Vec::with_capacity(parsed_files.len());
-                for parsed_file in &parsed_files {
-                    let mut diagram = self.make_mermaid(std::slice::from_ref(parsed_file));
-                    if !self.args.no_title {
-                        diagram.path = parsed_file
-                            .strip_prefix(root)
-                            .unwrap_or(parsed_file.as_path())
-                            .to_string_lossy()
-                            .into_owned();
-                    }
-                    diagrams.push(diagram);
-                }
-                return diagrams;
+                use rayon::prelude::*;
+                return parsed_files
+                    .par_iter()
+                    .map(|parsed_file| {
+                        let mut diagram = self.make_mermaid_for_file(parsed_file);
+                        if !self.args.no_title {
+                            diagram.path = parsed_file
+                                .strip_prefix(root)
+                                .unwrap_or(parsed_file.as_path())
+                                .to_string_lossy()
+                                .into_owned();
+                        }
+                        diagram
+                    })
+                    .collect();
             }
 
             let mut diagram = self.make_mermaid(&parsed_files);
@@ -95,21 +97,31 @@ impl Mermaider {
         vec![]
     }
 
-    fn make_mermaid(&self, parsed_files: &[PathBuf]) -> ClassDiagram {
+    fn make_mermaid_for_file(&self, file: &Path) -> ClassDiagram {
         let options = RenderOptions {
             direction: self.args.direction,
             hide_private_members: self.args.hide_private_members,
         };
-        let mut class_diagram = ClassDiagram::new(options);
-
-        for file in parsed_files {
-            let Ok(source) = std::fs::read_to_string(file) else {
-                continue;
-            };
-            class_diagram.add_file(&source, file);
+        let mut diagram = ClassDiagram::new(options);
+        if let Ok(source) = std::fs::read_to_string(file) {
+            diagram.add_file(&source, file);
         }
+        diagram
+    }
 
-        class_diagram
+    fn make_mermaid(&self, parsed_files: &[PathBuf]) -> ClassDiagram {
+        use rayon::prelude::*;
+        let options = RenderOptions {
+            direction: self.args.direction,
+            hide_private_members: self.args.hide_private_members,
+        };
+        let per_file: Vec<ClassDiagram> = parsed_files
+            .par_iter()
+            .map(|file| self.make_mermaid_for_file(file))
+            .collect();
+        per_file
+            .into_iter()
+            .fold(ClassDiagram::new(options), ClassDiagram::merge)
     }
 
     fn parse_folder(&self, path: &Path) -> Vec<PathBuf> {
@@ -374,6 +386,77 @@ mod tests {
 
         let rendered = diagrams[0].render().unwrap();
         assert!(!rendered.contains("title:"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_parallel_processing_is_deterministic() -> Result<()> {
+        init_logger();
+        let temp = TempDir::new()?;
+        std::fs::File::create(temp.path().join("base.py"))?.write_all(b"class Base: ...")?;
+        for i in 1..=5 {
+            let content = format!("class Child{i}(Base):\n    x: Base\n");
+            std::fs::File::create(temp.path().join(format!("child_{i}.py")))?
+                .write_all(content.as_bytes())?;
+        }
+
+        let render_with_threads = |num_threads: usize| -> String {
+            let mermaider = Mermaider::new(default_args(), default_settings(temp.path()));
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .build()
+                .unwrap();
+            pool.install(|| {
+                let diagrams = mermaider.generate_diagrams();
+                assert_eq!(diagrams.len(), 1);
+                diagrams[0].render().unwrap_or_default()
+            })
+        };
+
+        let single_threaded = render_with_threads(1);
+        let multi_threaded = render_with_threads(4);
+
+        assert_eq!(single_threaded, multi_threaded);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parallel_multiple_files_parity() -> Result<()> {
+        init_logger();
+        let temp = TempDir::new()?;
+        std::fs::File::create(temp.path().join("base.py"))?.write_all(b"class Base: ...")?;
+        for i in 1..=5 {
+            let content = format!("class Child{i}(Base):\n    x: Base\n");
+            std::fs::File::create(temp.path().join(format!("child_{i}.py")))?
+                .write_all(content.as_bytes())?;
+        }
+
+        let num_py_files = 6usize;
+
+        let run_with_threads = |num_threads: usize| -> Vec<(String, Option<String>)> {
+            let mut args = default_args();
+            args.multiple_files = true;
+            let mermaider = Mermaider::new(args, default_settings(temp.path()));
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .build()
+                .unwrap();
+            pool.install(|| {
+                let diagrams = mermaider.generate_diagrams();
+                assert_eq!(diagrams.len(), num_py_files);
+                let mut pairs: Vec<(String, Option<String>)> = diagrams
+                    .iter()
+                    .map(|d| (d.path.clone(), d.render()))
+                    .collect();
+                pairs.sort_by(|a, b| a.0.cmp(&b.0));
+                pairs
+            })
+        };
+
+        let single_threaded = run_with_threads(1);
+        let multi_threaded = run_with_threads(4);
+
+        assert_eq!(single_threaded, multi_threaded);
         Ok(())
     }
 }

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -119,6 +119,7 @@ pub struct Diagram {
     pub classes: Vec<ClassNode>,
     pub relationships: Vec<RelationshipEdge>,
     pub compositions: Vec<CompositionEdge>,
+    abstract_or_interface_index: std::collections::HashMap<String, bool>,
 }
 
 impl Diagram {
@@ -133,6 +134,13 @@ impl Diagram {
     }
 
     pub fn add_class(&mut self, class: ClassNode) {
+        let is_abstract_or_interface =
+            matches!(class.class_type, ClassType::Abstract | ClassType::Interface);
+        let entry = self
+            .abstract_or_interface_index
+            .entry(class.name.clone())
+            .or_insert(false);
+        *entry = *entry || is_abstract_or_interface;
         self.classes.push(class);
     }
 
@@ -146,9 +154,22 @@ impl Diagram {
 
     #[must_use]
     pub fn is_abstract_or_interface(&self, name: &str) -> bool {
-        self.classes.iter().any(|c| {
-            c.name == name && matches!(c.class_type, ClassType::Abstract | ClassType::Interface)
-        })
+        self.abstract_or_interface_index
+            .get(name)
+            .copied()
+            .unwrap_or(false)
+    }
+
+    pub fn extend(&mut self, other: Diagram) {
+        self.classes.extend(other.classes);
+        self.relationships.extend(other.relationships);
+        self.compositions.extend(other.compositions);
+        for (name, other_flag) in other.abstract_or_interface_index {
+            self.abstract_or_interface_index
+                .entry(name)
+                .and_modify(|v| *v = *v || other_flag)
+                .or_insert(other_flag);
+        }
     }
 
     /// Return classes in a deterministic topological order based on relationships and compositions,
@@ -216,5 +237,66 @@ impl Diagram {
             .into_iter()
             .filter_map(|name| class_map.get(name).copied())
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_diagram_extend_concatenates_all_fields() {
+        let mut a = Diagram::new();
+        a.add_class(ClassNode {
+            name: "A1".to_string(),
+            type_params: None,
+            class_type: ClassType::Regular,
+            attributes: vec![],
+            methods: vec![],
+        });
+        a.add_relationship(RelationshipEdge {
+            from: "A1".to_string(),
+            to: "Base".to_string(),
+            relation_type: RelationType::Inheritance,
+        });
+        a.add_composition(CompositionEdge {
+            container: "A1".to_string(),
+            contained: "Widget".to_string(),
+        });
+
+        let mut b = Diagram::new();
+        b.add_class(ClassNode {
+            name: "B1".to_string(),
+            type_params: None,
+            class_type: ClassType::Abstract,
+            attributes: vec![],
+            methods: vec![],
+        });
+        b.add_relationship(RelationshipEdge {
+            from: "B1".to_string(),
+            to: "Base".to_string(),
+            relation_type: RelationType::Implementation,
+        });
+        b.add_composition(CompositionEdge {
+            container: "B1".to_string(),
+            contained: "Gadget".to_string(),
+        });
+
+        a.extend(b);
+
+        assert_eq!(a.classes.len(), 2);
+        assert_eq!(a.classes[0].name, "A1");
+        assert_eq!(a.classes[1].name, "B1");
+
+        assert_eq!(a.relationships.len(), 2);
+        assert_eq!(a.relationships[0].to, "Base");
+        assert_eq!(a.relationships[1].to, "Base");
+
+        assert_eq!(a.compositions.len(), 2);
+        assert_eq!(a.compositions[0].contained, "Widget");
+        assert_eq!(a.compositions[1].contained, "Gadget");
+
+        assert!(a.is_abstract_or_interface("B1"));
+        assert!(!a.is_abstract_or_interface("A1"));
     }
 }


### PR DESCRIPTION
## Summary
- Parallelize file parsing/rendering across CPU cores using `rayon` (gated behind the `cli` feature only, so the wasm/lib build is unaffected). Each file's `ClassDiagram::add_file` builds a fresh `Checker`/`SemanticModel` with no cross-file shared state, so this is embarrassingly parallel. Applies to both combined mode (`Mermaider::make_mermaid`) and `--multiple-files` mode. Per-file results are collected into an order-preserving `Vec` and merged with a plain sequential `fold` (not `rayon::reduce`), so output is byte-identical regardless of thread count.
- Fix an O(n^2) lookup: `Diagram::is_abstract_or_interface` used to linearly scan all classes for every base class checked during `classify_base`. Replaced with an O(1) `HashMap<String, bool>` index maintained incrementally in `Diagram::add_class`, using OR-semantics (a name's flag, once true, is never reset to false) to exactly preserve the original `.any()` scan's behavior. The index is merged with the same OR-semantics in the new `Diagram::extend`/`ClassDiagram::merge` used by the parallel merge path.

## Changes
- `Cargo.toml`: add `rayon = { version = "1.10", optional = true }`; `cli` feature now includes `dep:rayon`.
- `src/render/renderer.rs`: add `abstract_or_interface_index: HashMap<String, bool>` field to `Diagram`, update `add_class`/`is_abstract_or_interface` to use it, add `Diagram::extend`.
- `src/class_diagram/mod.rs`: add `ClassDiagram::merge`.
- `src/mermaider.rs`: extract `make_mermaid_for_file`; rewrite `make_mermaid` to parse files in parallel via `par_iter().map().collect()` then a sequential `fold` merge; rewrite the `--multiple-files` branch of `generate_diagrams` to build diagrams in parallel directly.

## Test plan
- [x] `cargo test --lib --no-default-features` (confirms rayon/cli stays out of the wasm/lib build)
- [x] `cargo test --verbose` (full suite: 40 lib tests, 9 `src/mermaider.rs` tests incl. 2 new parallelism tests, 6 `tests/cli_io.rs` tests - all passing)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo check --lib --target wasm32-unknown-unknown --no-default-features` (clean)
- [x] New test: `test_parallel_processing_is_deterministic` - asserts combined-mode rendered output is byte-identical between 1-thread and 4-thread rayon pools, with cross-file inheritance fixtures.
- [x] New test: `test_parallel_multiple_files_parity` - asserts `--multiple-files` mode produces identical (path, rendered) pairs across thread counts, and diagram count always equals file count.
- [x] New test: `test_diagram_extend_concatenates_all_fields` - unit test verifying `Diagram::extend` concatenates classes/relationships/compositions in order and merges the abstract/interface index correctly.